### PR TITLE
Fix link error

### DIFF
--- a/bookmarks/common/core.py
+++ b/bookmarks/common/core.py
@@ -474,6 +474,8 @@ def get_links(path, section='links/asset'):
     v = s.value(section)
     if not v:
         return []
+    if not isinstance(v, (list, tuple)):
+        v = [v,]
 
     try:
         # Check validity of the list before returning anything
@@ -482,6 +484,9 @@ def get_links(path, section='links/asset'):
             file_info = QtCore.QFileInfo(f'{path}/{_v}')
             if file_info.exists():
                 links.append(_v.replace('\\', '/'))
+            else:
+                from .. import log
+                log.error(f'Link "{file_info.filePath()}" does not exist.')
         return sorted(links)
     except:
         return []

--- a/bookmarks/items/asset_items.py
+++ b/bookmarks/items/asset_items.py
@@ -310,7 +310,6 @@ class AssetItemModel(models.ItemModel):
         except OSError as e:
             log.error(e)
             return
-            yield
 
         # Get folders from the root of the bookmark item
         for entry in it:
@@ -329,7 +328,8 @@ class AssetItemModel(models.ItemModel):
             for link in links:
                 v = f'{path}/{entry.name}/{link}'
                 _entry = common.get_entry_from_path(v)
-                if not entry:
+                if not _entry:
+                    log.error(f'Could not get entry from link {v}')
                     continue
                 yield _entry
             if links:


### PR DESCRIPTION
Makes sure the stored link value in the .link file always evaluates as a list. Previous single values were read as strings that lead to incorrect behaviour.
I also added explicit error messages when a link is invalid or can't be resolved correctly.