### PR TITLE
Fix flag checking

### DIFF
--- a/bookmarks/items/views.py
+++ b/bookmarks/items/views.py
@@ -870,6 +870,7 @@ class BaseItemView(QtWidgets.QTableView):
                     'flags',
                     database.AssetTable
                 )
+                flags = flags if flags else 0
 
                 # Active items can't be archived
                 if flags & common.MarkedAsActive:


### PR DESCRIPTION
Make sure we check against a valid none-flag value when an item doesn't have a any database flag value set.