### PR TITLE
Add links to jobs

### DIFF
--- a/bookmarks/common/core.py
+++ b/bookmarks/common/core.py
@@ -499,7 +499,7 @@ def add_link(path, link, section='links/asset'):
         path (str): Path to a folder where the link file resides. E.g. an asset root folder.
         link (str): Relative path to the link file.
         section (str):
-            The settings section to look for links in. Defaults to `links/assets`.
+            The settings section to look for links in. Defaults to `links/asset`.
 
     """
     l = f'{path}/{common.link_file}'
@@ -508,6 +508,8 @@ def add_link(path, link, section='links/asset'):
     links = []
     if QtCore.QFileInfo(l).exists():
         links = s.value(section)
+        if links and not isinstance(links, (list, tuple)):
+            links = [links,]
     links = links if links else []
 
     # Make sure the link points to a valid file

--- a/bookmarks/common/settings.py
+++ b/bookmarks/common/settings.py
@@ -30,7 +30,6 @@ SECTIONS = {
         'user/favourites',
     ),
     'settings': (
-        'settings/jobs_have_clients',
         'settings/job_scan_depth',
         'settings/ui_scale',
         'settings/show_menu_icons',

--- a/bookmarks/editor/preferences.py
+++ b/bookmarks/editor/preferences.py
@@ -123,20 +123,6 @@ SECTIONS = {
             },
             1: {
                 0: {
-                    'name': 'Jobs have clients',
-                    'key': 'settings/jobs_have_clients',
-                    'validator': None,
-                    'widget': functools.partial(QtWidgets.QCheckBox, 'Enable'),
-                    'placeholder': '',
-                    'description': 'In case your job folder uses a client/project like '
-                                   'structure, tick this box. Leave it un-ticked if the '
-                                   'project folders are nested directly in the server'
-                                   'folder.',
-                    'help': 'Enable if jobs have separate <span style="color:white">client/project</span> folders. By '
-                            'default, Bookmarks assumes jobs are kept directly in the '
-                            'root of the server folder but you can override this here.'
-                },
-                1: {
                     'name': 'Bookmark item search depth',
                     'key': 'settings/job_scan_depth',
                     'validator': base.int_validator,


### PR DESCRIPTION
This allows removing the previously used, and clumsy 'job_has_clients' setting. This solution instead utilises our previously defined .links definition to indicate where nested job folders reside.

Also fixes a few minor linking related bugs.